### PR TITLE
Alow a new Service Provider option to disallow user login.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ class SamlServiceProviderRepository implements ServiceProviderRepository
                 "assertionNotBeforeInterval" => new \DateInterval('PT0S'),
                 "assertionNotOnOrAfterInterval" => new \DateInterval('PT5M'),
                 "assertionSessionNotOnOrAfterInterval" => new \DateInterval('P1D'),
+                "userAllowed" => function (UserInterface $user) {
+                    /** @var User $user */
+                    return $user->canLoginInTestFacke();
+                 },
             ]
         );
     }

--- a/src/Entity/ServiceProvider.php
+++ b/src/Entity/ServiceProvider.php
@@ -163,4 +163,19 @@ class ServiceProvider extends \SAML2\Configuration\ServiceProvider
     {
         return $this->get('validAudiences');
     }
+
+    /**
+     * @return bool|callable
+     */
+    public function isUserAllowed() {
+        return $this->get('userAllowed', true);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDescription() {
+        return $this->get('description', $this->getEntityId());
+    }
+
 }

--- a/src/Exception/UserNotAllowedInServiceProvider.php
+++ b/src/Exception/UserNotAllowedInServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AdactiveSas\Saml2BridgeBundle\Exception;
+
+use AdactiveSas\Saml2BridgeBundle\Entity\ServiceProvider;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException as SymfonyAccessDeniedException;
+
+class UserNotAllowedInServiceProvider extends SymfonyAccessDeniedException implements Exception
+{
+
+    private $sp;
+
+    /**
+     * Constructor.
+     * @param string $message
+     * @param \Throwable|null $previous
+     * @param ServiceProvider|null $sp
+     */
+    public function __construct(string $message = 'User not allowed to login in Service Provider.', \Throwable $previous = null, ServiceProvider $sp = null)
+    {
+        parent::__construct($message, $previous);
+        $this->sp = $sp;
+    }
+
+    /**
+     * @return null|ServiceProvider|null
+     */
+    public function getServiceProvider() {
+        return $this->sp;
+    }
+
+}


### PR DESCRIPTION
In real life use, not every user in Symfony Application can login in
your Service Providers.

This patch makes available a new option for service providers ,
'userAllowed', which can be defined as a callable and makes it posible
to define which users will be able to login to the SP.

When a user is not allowed, an UserNotAllowedInServiceProvider
exception will be thrown. It is a 403 symfony exception, but
includes the service provider variable, which can be use in a
custom error403.html.twig.

Also, a new config has been added to Service Providers called
'description' to get a human readable name for each SP.